### PR TITLE
Create almalinux.nyc.velocihost.net.yml

### DIFF
--- a/mirrors.d/almalinux.nyc.velocihost.net.yml
+++ b/mirrors.d/almalinux.nyc.velocihost.net.yml
@@ -1,0 +1,10 @@
+---
+name: mirror.nyc.velocihost.net
+address:
+  http: http://mirror.nyc.velocihost.net/almalinux/
+  https: https://mirror.nyc.velocihost.net/almalinux/
+update_frequency: 3h
+sponsor: VelociHOST
+sponsor_url: https://www.velocihost.net
+email: support@velocihost.net
+---


### PR DESCRIPTION
Hello team,

We gladly support the open-source community and would like to host AlmaLinux on VelociHOST New York mirror.

Thank you!